### PR TITLE
Don't over-evaluate user solutions

### DIFF
--- a/chatbot/pom.xml
+++ b/chatbot/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>de.ips.creactivities</groupId>
     <artifactId>chatbot</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <name>chatbot</name>
     <description>chatbot</description>
     <properties>

--- a/chatbot/src/main/java/de/ips/creactivities/chatbot/process/SendDifferentSolutionToUserDelegate.java
+++ b/chatbot/src/main/java/de/ips/creactivities/chatbot/process/SendDifferentSolutionToUserDelegate.java
@@ -1,5 +1,6 @@
 package de.ips.creactivities.chatbot.process;
 
+import de.ips.creactivities.chatbot.ChatbotProperties;
 import de.ips.creactivities.chatbot.cms.ICmsService;
 import de.ips.creactivities.chatbot.cms.dm.Challenge;
 import de.ips.creactivities.chatbot.cms.dm.ThirdPartyEvaluation;
@@ -38,6 +39,8 @@ public class SendDifferentSolutionToUserDelegate implements JavaDelegate {
     private SolutionRepository solutionRepository;
 
     private MessageSender messageSender;
+
+    private ChatbotProperties config;
 
     private ICmsService cmsService;
 
@@ -97,6 +100,10 @@ public class SendDifferentSolutionToUserDelegate implements JavaDelegate {
         SolutionEntity solutionToSend = null;
 
         for (SolutionEntity solution : result) {
+            if(solution.getEvaluations() != null && solution.getEvaluations().size() >= config.getNumberOfRequiredEvaluations()) {
+                // we can cancel running through this list. Due to the sorting, the rest of the list has equal or more evaluations.
+                break;
+            }
             if (!alreadyEvaluatedByMe(user, solution) && !solution.isBlocked()) {
                 solutionToSend = solution;
                 break;
@@ -150,7 +157,6 @@ public class SendDifferentSolutionToUserDelegate implements JavaDelegate {
 
         List<ChallengeEntity> challenges = new ArrayList<>();
         if (user.getSolutions() != null) {
-
             for (SolutionEntity solution : user.getSolutions()) {
                 challenges.add(solution.getChallenge());
             }
@@ -183,4 +189,7 @@ public class SendDifferentSolutionToUserDelegate implements JavaDelegate {
     public void setCmsService(ICmsService cmsService) {
         this.cmsService = cmsService;
     }
+
+    @Autowired
+    public void setChatbotProperties(ChatbotProperties props) { this.config = props; }
 }


### PR DESCRIPTION
Tests are green, I do not have the setup anymore to manually test this, however the change seems small enough.
Essentially what we're now doing is we fetch all eligible solutions for evaluation, sort them ascending by number of already present evaluations and - given we hit a solution that already has equal or greater than the amount of required evaluations - break the loop that checks whether to offer the solution to the user. This automatically causes the "selected solution" to stay 'null', which causes the bot to offer an admin solution instead.